### PR TITLE
[bug?] parsing file of CRLF format with getline()

### DIFF
--- a/basic-3d-rendering/input-geometry/loading-from-file.md
+++ b/basic-3d-rendering/input-geometry/loading-from-file.md
@@ -91,6 +91,12 @@ bool loadGeometry(const fs::path& path, std::vector<float>& pointData, std::vect
 	std::string line;
 	while (!file.eof()) {
 		getline(file, line);
+		
+		// overcome the `CRLF` problem
+	        if (!line.empty() && line.back() == '\r') {
+	          line.pop_back();
+	        }
+		
 		if (line == "[points]") {
 			currentSection = Section::Points;
 		}


### PR DESCRIPTION
I tested the simple parser on my `Windows` laptop, but it crashed because the `getline` function by default ends when the input character is `\n`.

On the Windows platform, it is commonplace to use `\r\n` (Carriage Return Line Feed) format to make a new line.

The ascii result shows below
```text
91 112 111 105 110 116 115 93 13 
35 32 120 32 32 32 121 32 32 32 32 32 32 114 32 32 32 103 32 32 32 98 13 
13 
48 46 53 32 32 32 48 46 48 32 32 32 32 48 46 48 32 48 46 51 53 51 32 48 46 54 49 50 13 
49 46 48 32 32 32 48 46 56 54 54 32 32 48 46 48 32 48 46 51 53 51 32 48 46 54 49 50 13 
48 46 48 32 32 32 48 46 56 54 54 32 32 48 46 48 32 48 46 51 53 51 32 48 46 54 49 50 13 
13 
48 46 55 53 32 32 48 46 52 51 51 32 32 48 46 48 32 48 46 52 32 32 32 48 46 55 13 
49 46 50 53 32 32 48 46 52 51 51 32 32 48 46 48 32 48 46 52 32 32 32 48 46 55 13 
49 46 48 32 32 32 48 46 56 54 54 32 32 48 46 48 32 48 46 52 32 32 32 48 46 55 13 
13 
49 46 48 32 32 32 48 46 48 32 32 32 32 48 46 48 32 48 46 52 54 51 32 48 46 56 13 
49 46 50 53 32 32 48 46 52 51 51 32 32 48 46 48 32 48 46 52 54 51 32 48 46 56 13 
48 46 55 53 32 32 48 46 52 51 51 32 32 48 46 48 32 48 46 52 54 51 32 48 46 56 13 
13 
49 46 50 53 32 32 48 46 52 51 51 32 32 48 46 48 32 48 46 53 50 53 32 48 46 57 49 13 
49 46 51 55 53 32 48 46 54 53 32 32 32 48 46 48 32 48 46 53 50 53 32 48 46 57 49 13 
49 46 49 50 53 32 48 46 54 53 32 32 32 48 46 48 32 48 46 53 50 53 32 48 46 57 49 13 
13 
49 46 49 50 53 32 48 46 54 53 32 32 32 48 46 48 32 48 46 53 55 54 32 49 46 48 13 
49 46 51 55 53 32 48 46 54 53 32 32 32 48 46 48 32 48 46 53 55 54 32 49 46 48 13 
49 46 50 53 32 32 48 46 56 54 54 32 32 48 46 48 32 48 46 53 55 54 32 49 46 48 13 
13 
91 105 110 100 105 99 101 115 93 13 
32 48 32 32 49 32 32 50 13 
32 51 32 32 52 32 32 53 13 
32 54 32 32 55 32 32 56 13 
32 57 32 49 48 32 49 49 13 
49 50 32 49 51 32 49 52 
```