### PR TITLE
Minor typo in "The Device"

### DIFF
--- a/getting-started/the-device.md
+++ b/getting-started/the-device.md
@@ -50,7 +50,7 @@ WGPUDevice requestDevice(WGPUAdapter adapter, WGPUDeviceDescriptor const * descr
 		if (status == WGPURequestDeviceStatus_Success) {
 			userData.device = device;
 		} else {
-			std::cout << "Could not get WebGPU adapter: " << message << std::endl;
+			std::cout << "Could not get WebGPU device: " << message << std::endl;
 		}
 		userData.requestEnded = true;
 	};


### PR DESCRIPTION
Hi! Thanks for your great tutorial book!

I noticed a minor typo in the following error message.

```cpp
std::cout << "Could not get WebGPU adapter: " << message << std::endl;
```