### PR TITLE
[The Device Chapter] Correct struct member syntax

### DIFF
--- a/getting-started/the-device.md
+++ b/getting-started/the-device.md
@@ -189,7 +189,7 @@ For now we will initialize this to a very minimal option:
 ```{lit} C++, Build device descriptor
 deviceDesc.nextInChain = nullptr;
 deviceDesc.label = "My Device"; // anything works here, that's your call
-deviceDesc.requiredFeaturesCount = 0; // we do not require any specific feature
+deviceDesc.requiredFeatureCount = 0; // we do not require any specific feature
 deviceDesc.requiredLimits = nullptr; // we do not require any specific limit
 deviceDesc.defaultQueue.nextInChain = nullptr;
 deviceDesc.defaultQueue.label = "The default queue";


### PR DESCRIPTION
A structure member in the device setup is called as
`deviceDesc.requiredFeaturesCount`

but in the `webgpu.h` header is called
`deviceDesc.requiredFeatureCount`

i removed the extra 's' char to avoid misunderstandings and errors in the implementation