### PR TITLE
[Documentation] Add missing hpp sections for first chapter

### DIFF
--- a/getting-started/hello-webgpu.md
+++ b/getting-started/hello-webgpu.md
@@ -164,7 +164,8 @@ int main (int, char**) {
 
 The instance is created using the `wgpuCreateInstance` function. Like all WebGPU functions meant to **create** an entity, it takes as argument a **descriptor**, which we can use to specify options regarding how to set up this object.
 
-```{lit} C++, Create WebGPU instance
+````{tab} with webgpu.h
+```{lit} C, -Vanilla Create WebGPU instance
 // 1. We create a descriptor
 WGPUInstanceDescriptor desc = {};
 desc.nextInChain = nullptr;
@@ -172,6 +173,17 @@ desc.nextInChain = nullptr;
 // 2. We create the instance using this descriptor
 WGPUInstance instance = wgpuCreateInstance(&desc);
 ```
+````
+
+````{tab} with webgpu.hpp
+```{lit} C++, Create WebGPU instance
+// 1. We create a descriptor
+wgpu::DeviceDescriptor desc = {};
+
+// 2. We create the instance using this descriptor
+wgpu::Instance instance = wgpu::createInstance(desc);
+```
+````
 
 ```{note}
 The descriptor is a kind of way to pack many function arguments together, because some descriptors really have a lot of fields. It can also be used to write utility functions that take care of populating the arguments, to ease the program's architecture.
@@ -226,10 +238,20 @@ wgpuSomethingRelease(sth);
 
 In particular, we need to release the global WebGPU instance:
 
+
+````{tab} with webgpu.h
+```{lit} C++, -Vanilla Destroy WebGPU instance
+// 5. We clean up the WebGPU instance
+wgpuInstanceRelease(instance);
+```
+````
+
+`````{tab} with webgpu.hpp
 ```{lit} C++, Destroy WebGPU instance
 // 5. We clean up the WebGPU instance
 wgpuInstanceRelease(instance);
 ```
+`````
 
 ````{note}
 In older versions of `wgpu-native`, the Release and Reference functions did not exist, and a Drop function was used to immediately free an object. See details in [this GitHub issue](https://github.com/webgpu-native/webgpu-headers/issues/9).

--- a/getting-started/the-adapter.md
+++ b/getting-started/the-adapter.md
@@ -126,7 +126,8 @@ WGPUAdapter requestAdapter(WGPUInstance instance, WGPURequestAdapterOptions cons
 
 In the main function, after opening the window, we can get the adapter:
 
-```{lit} C++, Request adapter
+````{tab} with webgpu.h
+```{lit} C++, -Vanilla Request adapter
 std::cout << "Requesting adapter..." << std::endl;
 
 WGPURequestAdapterOptions adapterOpts = {};
@@ -134,6 +135,18 @@ WGPUAdapter adapter = requestAdapter(instance, &adapterOpts);
 
 std::cout << "Got adapter: " << adapter << std::endl;
 ```
+````
+
+````{tab} with webgpu.hpp
+```{lit} C++, Request adapter
+std::cout << "Requesting adapter..." << std::endl;
+
+wgpu::RequestAdapterOptions adapterOpts = {};
+WGPUAdapter adapter = requestAdapter(instance, &adapterOpts);
+
+std::cout << "Got adapter: " << adapter << std::endl;
+```
+````
 
 ### Destruction
 
@@ -192,8 +205,8 @@ The Surface
 ```
 
 We actually need to pass an option to the adapter request: the **surface** onto which we draw.
-
-```{lit} C++, Request adapter (replace)
+````{tab} with webgpu.h
+```{lit} C++, -Vanilla Request adapter (replace)
 {{Get the surface}}
 
 WGPURequestAdapterOptions adapterOpts = {};
@@ -202,6 +215,19 @@ adapterOpts.compatibleSurface = surface;
 
 WGPUAdapter adapter = requestAdapter(instance, &adapterOpts);
 ```
+````
+
+````{tab} with webgpu.hpp
+```{lit} C++, Request adapter (replace)
+{{Get the surface}}
+
+wgpu::RequestAdapterOptions adapterOpts = {};
+adapterOpts.nextInChain = nullptr;
+adapterOpts.compatibleSurface = surface;
+
+WGPUAdapter adapter = requestAdapter(instance, &adapterOpts);
+```
+````
 
 How do we get the surface? This depends on the OS, and GLFW does not handle this for us, for it does not know WebGPU (yet?). So I provide you this function, in a little extension to GLFW3 called [`glfw3webgpu`](https://github.com/eliemichel/glfw3webgpu).
 

--- a/getting-started/the-command-queue.md
+++ b/getting-started/the-command-queue.md
@@ -127,12 +127,24 @@ Command encoder
 
 A command encoder is created following the usual object creation idiom of WebGPU:
 
-```{lit} C++, Create Command Encoder
+````{tab} with webgpu.h
+```{lit} C++, -Vanilla Create Command Encoder
 WGPUCommandEncoderDescriptor encoderDesc = {};
 encoderDesc.nextInChain = nullptr;
 encoderDesc.label = "My command encoder";
 WGPUCommandEncoder encoder = wgpuDeviceCreateCommandEncoder(device, &encoderDesc);
 ```
+````
+
+````{tab} with webgpu.hpp
+```{lit} C++, Create Command Encoder
+wgpu::CommandEncoderDescriptor encoderDesc = {};
+encoderDesc.nextInChain = nullptr;
+encoderDesc.label = "My command encoder";
+WGPUCommandEncoder encoder = wgpuDeviceCreateCommandEncoder(device, &encoderDesc);
+```
+````
+
 
 We can now use the encoder to write instructions (debug placeholder for now).
 
@@ -143,13 +155,26 @@ wgpuCommandEncoderInsertDebugMarker(encoder, "Do another thing");
 
 And then finally generating the command from the encoder also requires an extra descriptor:
 
-```{lit} C++, Finish encoding and submit
+````{tab} with webgpu.h
+```{lit} C++, -Vanilla Finish encoding and submit
 WGPUCommandBufferDescriptor cmdBufferDescriptor = {};
 cmdBufferDescriptor.nextInChain = nullptr;
 cmdBufferDescriptor.label = "Command buffer";
 WGPUCommandBuffer command = wgpuCommandEncoderFinish(encoder, &cmdBufferDescriptor);
+```
+````
+
+````{tab} with webgpu.hpp
+```{lit} C++, Finish encoding and submit
+wgpu::CommandBufferDescriptor cmdBufferDescriptor = {};
+cmdBufferDescriptor.nextInChain = nullptr;
+cmdBufferDescriptor.label = "Command buffer";
+WGPUCommandBuffer command = wgpuCommandEncoderFinish(encoder, &cmdBufferDescriptor);
+```
+````
 
 // Finally submit the command queue
+```
 std::cout << "Submitting command..." << std::endl;
 wgpuQueueSubmit(queue, 1, &command);
 

--- a/getting-started/the-device.md
+++ b/getting-started/the-device.md
@@ -140,8 +140,8 @@ webgpu-utils.cpp
 ```
 
 In the main function, after getting the adapter, we can request the device:
-
-```{lit} C++, Request device
+````{tab} with webgpu.h
+```{lit} C++, -Vanilla Request device
 std::cout << "Requesting device..." << std::endl;
 
 WGPUDeviceDescriptor deviceDesc = {};
@@ -150,6 +150,20 @@ WGPUDevice device = requestDevice(adapter, &deviceDesc);
 
 std::cout << "Got device: " << device << std::endl;
 ```
+````
+
+````{tab} with webgpu.hpp
+```{lit} C++, Request device
+std::cout << "Requesting device..." << std::endl;
+
+wgpu::DeviceDescriptor deviceDesc = {};
+{{Build device descriptor}}
+WGPUDevice device = requestDevice(adapter, &deviceDesc);
+
+std::cout << "Got device: " << device << std::endl;
+```
+````
+
 
 ```{lit} C++, Create things (append, hidden)
 {{Request device}}


### PR DESCRIPTION
Adds the C++ equivalent of the code that is showed in the first chapters, so the users won't have to convert everything step by step from C to C++ when introducing the C++ Wrapper.