### PR TITLE
Fixed vanilla buffer get map function.

### DIFF
--- a/basic-3d-rendering/input-geometry/playing-with-buffers.md
+++ b/basic-3d-rendering/input-geometry/playing-with-buffers.md
@@ -298,7 +298,7 @@ auto onBuffer2Mapped = [](WGPUBufferMapAsyncStatus status, void* pUserData) {
 	if (status != WGPUBufferMapAsyncStatus_Success) return;
 
 	// Get a pointer to wherever the driver mapped the GPU memory to the RAM
-	uint8_t* bufferData = (uint8_t*)wgpuBufferGetMappedRange(context->buffer, 0, 16);
+	uint8_t* bufferData = (uint8_t*)wgpuBufferGetConstMappedRange(context->buffer, 0, 16);
 
 	// [...] (Do stuff with bufferData)
 


### PR DESCRIPTION
The example code for the vanilla header correctly used the `wgpuBufferGetConstMappedRange` function, however the guide code block had it as `wgpuBufferGetMappedRange`.