### PR TITLE
Fixed typo in setting `enable_immediate_error_handling` for Dawn

### DIFF
--- a/next/getting-started/adapter-and-device/the-device.md
+++ b/next/getting-started/adapter-and-device/the-device.md
@@ -353,8 +353,8 @@ desc.nextInChain = nullptr;
 WGPUDawnTogglesDescriptor toggles;
 toggles.chain.next = nullptr;
 toggles.chain.sType = WGPUSType_DawnTogglesDescriptor;
-toggles.disabledToggleCount = 0;
-toggles.enabledToggleCount = 1;
+toggles.disabledTogglesCount = 0;
+toggles.enabledTogglesCount = 1;
 const char* toggleName = "enable_immediate_error_handling";
 toggles.enabledToggles = &toggleName;
 


### PR DESCRIPTION
Just fixed some typos for setting immediate error handling for Dawn, instead of at device ticks.