### PR TITLE
Fix wgpuGetLimits on Dawn in adapter and device chapters

### DIFF
--- a/getting-started/adapter-and-device/the-adapter.md
+++ b/getting-started/adapter-and-device/the-adapter.md
@@ -334,7 +334,11 @@ We can first list the limits that our adapter supports with `wgpuAdapterGetLimit
 #ifndef __EMSCRIPTEN__
 WGPUSupportedLimits supportedLimits = {};
 supportedLimits.nextInChain = nullptr;
+#ifdef WEBGPU_BACKEND_DAWN
+bool success = wgpuAdapterGetLimits(adapter, &supportedLimits) == WGPUStatus_Success;
+#else
 bool success = wgpuAdapterGetLimits(adapter, &supportedLimits);
+#endif
 if (success) {
 	std::cout << "Adapter limits:" << std::endl;
 	std::cout << " - maxTextureDimension1D: " << supportedLimits.limits.maxTextureDimension1D << std::endl;

--- a/getting-started/adapter-and-device/the-device.md
+++ b/getting-started/adapter-and-device/the-device.md
@@ -246,7 +246,11 @@ void inspectDevice(WGPUDevice device) {
 
 	WGPUSupportedLimits limits = {};
 	limits.nextInChain = nullptr;
+#ifdef WEBGPU_BACKEND_DAWN
+	bool success = wgpuDeviceGetLimits(device, &limits) == WGPUStatus_Success;
+#else
 	bool success = wgpuDeviceGetLimits(device, &limits);
+#endif
 	if (success) {
 		std::cout << "Device limits:" << std::endl;
 		std::cout << " - maxTextureDimension1D: " << limits.limits.maxTextureDimension1D << std::endl;


### PR DESCRIPTION
Hello, thank you for making these tutorials. I have just started learning from them and am using Dawn as my webgpu backend.

I found that `wgpuAdapterGetLimits` on Dawn returns the `WGPUStatus` enum instead of a `WGPUBool` like it does on wgpu-native. Unfortunately `WGPUStatus_Success` is a falsy value so the if statement fails without these changes.

The full method declaration on Dawn in `webgpu.h` is
```cpp
WGPU_EXPORT WGPUStatus wgpuAdapterGetLimits(WGPUAdapter adapter, WGPUSupportedLimits * limits) WGPU_FUNCTION_ATTRIBUTE;
```

It appears that this change was done in https://github.com/google/dawn/commit/64f1a70d2c466df23001f4846508e8c3ddf52713 about 3 weeks ago.


**EDIT:** I found the same discrepancy with `wgpuDeviceGetLimits` in the device chapter, so I also made changes there.
