### PR TITLE
Fix Dawn toggleCount member names in device chapter

### DIFF
--- a/getting-started/adapter-and-device/the-device.md
+++ b/getting-started/adapter-and-device/the-device.md
@@ -353,8 +353,8 @@ desc.nextInChain = nullptr;
 WGPUDawnTogglesDescriptor toggles;
 toggles.chain.next = nullptr;
 toggles.chain.sType = WGPUSType_DawnTogglesDescriptor;
-toggles.disabledTogglesCount = 0;
-toggles.enabledTogglesCount = 1;
+toggles.disabledToggleCount = 0;
+toggles.enabledToggleCount = 1;
 const char* toggleName = "enable_immediate_error_handling";
 toggles.enabledToggles = &toggleName;
 


### PR DESCRIPTION
Fixes the names of `enabledToggleCount` and `disabledToggleCount` members in the device chapter.

EDIT: Looks like it was changed in this commit, so I suppose it's not a typo: https://github.com/google/dawn/commit/44fc9da6f3a178b50feb434f2725083f10748659