### PR TITLE
Add type when defining surface.

### DIFF
--- a/getting-started/opening-a-window.md
+++ b/getting-started/opening-a-window.md
@@ -455,7 +455,7 @@ You can now get the surface by simply doing:
 ```
 
 ```{lit} C++, Get the surface
-surface = glfwGetWGPUSurface(instance, window);
+WGPUSurface surface = glfwGetWGPUSurface(instance, window);
 ```
 
 Also don't forget to release the surface at the end:


### PR DESCRIPTION
`surface` has not been defined at this point in the tutorial, so add the type to the definition.