### PR TITLE
Correct playing-with-buffers's claim about `WGPUBufferMapAsyncStatus::Success`

### DIFF
--- a/basic-3d-rendering/input-geometry/playing-with-buffers.md
+++ b/basic-3d-rendering/input-geometry/playing-with-buffers.md
@@ -353,7 +353,7 @@ while (!ready) {
 }
 ```
 
-You could now see `Buffer 2 mapped with status 0` (0 being the value of `BufferMapAsyncStatus::Success`) when running your program. **However**, we never change the `ready` variable to `true`! So the program then **halts forever**... not great. That is why the next section shows how to pass some context to the callback.
+You could now see `Buffer 2 mapped with status 1` (1 being the value of `BufferMapAsyncStatus::Success`) when running your program. **However**, we never change the `ready` variable to `true`! So the program then **halts forever**... not great. That is why the next section shows how to pass some context to the callback.
 
 ### Mapping context
 


### PR DESCRIPTION
As can be seen [here](https://github.com/eliemichel/WebGPU-Cpp/blob/main/dawn/webgpu.h#L374):

```
WGPUBufferMapAsyncStatus_Success = 0x00000001
```

However the book claims `Success` is `0`. 