### PR TITLE
Fixed minor explanation details on playing-with-buffers.md

### DIFF
--- a/basic-3d-rendering/input-geometry/playing-with-buffers.md
+++ b/basic-3d-rendering/input-geometry/playing-with-buffers.md
@@ -353,7 +353,7 @@ while (!ready) {
 }
 ```
 
-You could now see `Buffer 2 mapped with status 1` (1 being the value of `BufferMapAsyncStatus::Success`) when running your program. **However**, we never change the `ready` variable to `true`! So the program then **halts forever**... not great. That is why the next section shows how to pass some context to the callback.
+You could now see `Buffer 2 mapped with status 1` (1 being the value of `BufferMapAsyncStatus::Success`) when running your program. **However**, we never change the `ready` variable to `true`! So the program then **hangs forever**... not great. That is why the next section shows how to pass some context to the callback.
 
 ### Mapping context
 


### PR DESCRIPTION
A very small fix but the documentation states

> So the program then **halts forever**...

It is supposed to convey that the program never halts or gets stuck in a loop.
Changed to:

> So the program then **hangs forever**