### PR TITLE
Fix texture view not renderable error

### DIFF
--- a/getting-started/first-color.md
+++ b/getting-started/first-color.md
@@ -234,6 +234,7 @@ viewDescriptor.mipLevelCount = 1;
 viewDescriptor.baseArrayLayer = 0;
 viewDescriptor.arrayLayerCount = 1;
 viewDescriptor.aspect = WGPUTextureAspect_All;
+viewDescriptor.usage = WGPUTextureUsage_RenderAttachment | WGPUTextureUsage_TextureBinding;
 WGPUTextureView targetView = wgpuTextureCreateView(surfaceTexture.texture, &viewDescriptor);
 ```
 


### PR DESCRIPTION
I found out that, at least since I started following, It's required to explicitly state the usage of the texture view to avoid the following error:

(tested with wgpu-native as backend)

```txt
In wgpuRenderPassEncoderEnd
    In a pass parameter
      The color attachment at index 0's texture view is not renderable:
        The texture this view references doesn't include the RENDER_ATTACHMENT usage. Provided usages: TextureUsages(TEXTURE_BINDING)
```

P.S. I know that the TEXTURE_BINDING usage is implicit in texture views