### PR TITLE
Fix memory leak when presenting with wgpu-native as backend

### DIFF
--- a/getting-started/first-color.md
+++ b/getting-started/first-color.md
@@ -183,7 +183,7 @@ We then simply call this function at the beginning of the main loop and check th
 
 ```{lit} C++, Get the next target texture view
 // Get the next target texture view
-auto [surfaceTexture, targetView] = surfacePresent();
+auto [surfaceTexture, targetView] = GetNextSurfaceTextureView();
 if (!targetView) return;
 ```
 
@@ -192,7 +192,7 @@ Do not forget to **declare the method** in the `Application` class declaration. 
 
 ```{lit} C++, Private methods (insert in {{Application class}} after "bool IsRunning();")
 private:
-    WGPUTextureView surfacePresent();
+    WGPUTextureView GetNextSurfaceTextureView();
 ```
 ````
 


### PR DESCRIPTION
Debugging my app in VS2022 I noticed a considerable memory leak in progress from the memory view. After double checking my code against the guide I started doubting the problem could be with the awkward texture management with wgpu-native. The guide states there is no need to manually release the texture in wgpu-native but in reality it must be done, just not in the same place as in Dawn. After a few tests I concluded the texture must in fact be release after the call to wgpuSurfacePresent(). Here's how I solved it in my engine, it's not elegant but it should work for now:

```cpp
std::pair<WGPUSurfaceTexture, WGPUTextureView> getNextSurfaceViewData()
{
    WGPUSurfaceTexture surfaceTexture;

    wgpuSurfaceGetCurrentTexture(m_surface, &surfaceTexture);

    if (surfaceTexture.status != WGPUSurfaceGetCurrentTextureStatus_SuccessOptimal)
    {
        return std::pair<WGPUSurfaceTexture, WGPUTextureView>(nullptr, nullptr);
    }

    WGPUTextureViewDescriptor viewDescriptor;
    viewDescriptor.nextInChain = nullptr;
    viewDescriptor.label = WGPUStringView("Surface texture view", 21);
    viewDescriptor.format = wgpuTextureGetFormat(surfaceTexture.texture);
    viewDescriptor.dimension = WGPUTextureViewDimension_2D;
    viewDescriptor.baseMipLevel = 0;
    viewDescriptor.mipLevelCount = 1;
    viewDescriptor.baseArrayLayer = 0;
    viewDescriptor.arrayLayerCount = 1;
    viewDescriptor.aspect = WGPUTextureAspect_All;
    viewDescriptor.usage = WGPUTextureUsage_RenderAttachment | WGPUTextureUsage_TextureBinding;

    WGPUTextureView targetView = wgpuTextureCreateView(surfaceTexture.texture, &viewDescriptor);

#ifndef WEBGPU_BACKEND_WGPU
    wgpuTextureRelease(surfaceTexture.texture);
#endif

    return std::pair<WGPUSurfaceTexture, WGPUTextureView>(surfaceTexture, targetView);
}

...

void draw()
{
    auto [surfaceTexture, targetView] = getNextSurfaceViewData();

    if (!targetView)
    {
        MOSAIC_ERROR("Could not get WebGPU target view!");
        return;
    }

    std::vector<WGPUCommandBuffer> commands;

    WGPUCommandEncoder encoder = createCommandEncoder(m_device, "Clear Screen Encoder");

    WGPURenderPassEncoder renderPass =
        beginRenderPass(encoder, targetView, {0.25f, 0.1f, 0.5f, 1.0f});

    // Draw calls go here...

    endRenderPass(renderPass);

    WGPUCommandBufferDescriptor cmdBufferDescriptor = {};
    cmdBufferDescriptor.nextInChain = nullptr;
    cmdBufferDescriptor.label = WGPUStringView("Command buffer", 15);

    WGPUCommandBuffer command = createCommandBuffer(encoder, cmdBufferDescriptor);

    commands.push_back(command);

    submitCommands(m_presentQueue, commands);

    pollDevice();

    wgpuTextureViewRelease(targetView);

#ifndef __EMSCRIPTEN__
    wgpuSurfacePresent(m_surface);
#endif

#ifdef WEBGPU_BACKEND_WGPU
    wgpuTextureRelease(surfaceTexture.texture);
#endif
}
```

I shouldn't have missed anything while updating the guide but it's worth checking. I hope this is useful. Bye!