### PR TITLE
Remove reference to non-existing page

### DIFF
--- a/basic-3d-rendering/hello-triangle.md
+++ b/basic-3d-rendering/hello-triangle.md
@@ -40,7 +40,7 @@ wgpuRenderPassEncoderDraw(renderPass, 3, 1, 0, 0);
 ```
 ````
 
-What is a bit verbose is the configuration of the **render pipeline**, and the creation of **shaders**. Luckily, we already introduced a lot of key concepts in chapter [*Our first shader*](../getting-started/our-first-shader.md), the main new element here is the render pipeline
+What is a bit verbose is the configuration of the **render pipeline**, and the creation of **shaders**.
 
 Render Pipeline
 ---------------


### PR DESCRIPTION
The "our first shader" page does not seem to exist anymore, so removing the reference to it.