### PR TITLE
update link to point at most recent tagged branch of webGPU distribution

### DIFF
--- a/getting-started/hello-webgpu.md
+++ b/getting-started/hello-webgpu.md
@@ -71,7 +71,7 @@ Since `wgpu-native` is written in rust, we cannot easily build it from scratch s
 **WIP:** Use the "for any platform" link rather than the platform-specific ones, I haven't automated their generation yet so they are usually behind the main one.
 ```
 
- - [wgpu-native for any platform](https://github.com/eliemichel/WebGPU-distribution/archive/refs/tags/wgpu-v0.19.4.1.zip) (a bit heavier as it's a merge of all possible platforms)
+ - [wgpu-native for any platform](https://github.com/eliemichel/WebGPU-distribution/archive/refs/tags/wgpu-v24.0.0.2.zip) (a bit heavier as it's a merge of all possible platforms)
  - [wgpu-native for Linux](#)
  - [wgpu-native for Windows](#)
  - [wgpu-native for MacOS](#)


### PR DESCRIPTION
Using the current link to WebGPU distribution v0.19.4.1 on my arm mac results in:
```
make[2]: *** No rule to make target `/Users/<username>/<path-to-project>/webgpu/bin/macos-arm64/libwgpu_native.dylib', needed by `App'.  Stop.
```

While looking into making a pull request on the [WebGPU distribution](https://github.com/eliemichel/WebGPU-distribution/tree/main) repo, I saw that the new version of the cmake file in main and the v24.0.0.2 tagged branches are incompatible with my local fixes. Version 24 seems to resolve my build issues, and updating the link seems better than patching an older tagged version.

Thank you for your time, and thank you for writing this amazing guide.